### PR TITLE
Support syntax highlighting of fram code blocks

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,3 +5,6 @@ language = "en"
 
 [preprocessor.katex]
 after = ["links"]
+
+[output.html]
+additional-js = ["js/highlight-fram.js"]

--- a/js/highlight-fram.js
+++ b/js/highlight-fram.js
@@ -1,0 +1,31 @@
+hljs.registerLanguage("fram", function (hljs) {
+  return {
+    keywords: {
+      keyword:
+        "abstr as data effect effrow else end extern finally fn handle handler " +
+        "if implicit import in label let match method module of open pub " +
+        "rec return then type with _",
+      literal: "True False",
+    },
+    contains: [
+      hljs.APOS_STRING_MODE,
+      hljs.QUOTE_STRING_MODE,
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.COMMENT("\\(\\*", "\\*\\)"),
+      {
+        className: "type",
+        begin: "\\b[A-Z]\\w*",
+      },
+      {
+        className: "number",
+        begin: "\\b(0[bB][01]*|0[oO][0-7]*|[0-9]+|0[xX][0-9a-fA-F]*)L?",
+      },
+    ],
+  };
+});
+
+// Additional scripts are loaded after the `book.js` file, which is responsible for hihghlighting code blocks.
+// That means that the `fram` language is not yet registered when the code blocks are highlighted.
+// Triggering highlighting here again fixes the issue, but it still leaves warning in the console though.
+// See https://github.com/rust-lang/mdBook/issues/657#issuecomment-924556465
+hljs.initHighlightingOnLoad();


### PR DESCRIPTION
This change allows to write fram code blocks in markdown. Their syntax will be highlighted in the book.

Code blocks should be annotated as the `fram` language, like this:

````md
```fram
(* Should be highlighted *)
pub let hello = "world"
```
````

It will probably be more useful when there is an actual documentation that includes fram code blocks.