### PR TITLE
Update syntax highlighting of Fram comments

### DIFF
--- a/js/highlight-fram.js
+++ b/js/highlight-fram.js
@@ -1,4 +1,18 @@
 hljs.registerLanguage("fram", function (hljs) {
+  // Based on `hljs.END_SAME_AS_BEGIN`, which is included with highlight.js.
+  // Here we only require that the opening match group is a suffix of the
+  // closing one. Used for Fram comments.
+  function MATCH_BEGIN_END(mode) {
+    return Object.assign(mode,
+      { 'on:begin': (m, resp) =>
+          { resp.data._beginMatch = m[1]; },
+        'on:end':   (m, resp) =>
+          { if (!m[1].endsWith(resp.data._beginMatch)) resp.ignoreMatch(); }
+      });
+  }
+
+  const COMMENT_NAME = "([a-zA-Z<>&\\$\\?!@\\^\\+\\-~\\*%;,=|:\\.\\/#]*)";
+
   return {
     keywords: {
       keyword:
@@ -10,8 +24,8 @@ hljs.registerLanguage("fram", function (hljs) {
     contains: [
       hljs.APOS_STRING_MODE,
       hljs.QUOTE_STRING_MODE,
-      hljs.C_LINE_COMMENT_MODE,
-      hljs.COMMENT("\\(\\*", "\\*\\)"),
+      hljs.HASH_COMMENT_MODE,
+      MATCH_BEGIN_END(hljs.COMMENT("{#" + COMMENT_NAME, COMMENT_NAME + "#}")),
       {
         className: "type",
         begin: "\\b[A-Z]\\w*",

--- a/js/highlight-fram.js
+++ b/js/highlight-fram.js
@@ -11,7 +11,7 @@ hljs.registerLanguage("fram", function (hljs) {
       });
   }
 
-  const COMMENT_NAME = "([a-zA-Z<>&\\$\\?!@\\^\\+\\-~\\*%;,=|:\\.\\/#]*)";
+  const COMMENT_NAME = "([\\w'<>&$?!@^+\\-~*%;,=|:./#]*)";
 
   return {
     keywords: {
@@ -28,7 +28,7 @@ hljs.registerLanguage("fram", function (hljs) {
       MATCH_BEGIN_END(hljs.COMMENT("{#" + COMMENT_NAME, COMMENT_NAME + "#}")),
       {
         className: "type",
-        begin: "\\b[A-Z]\\w*",
+        begin: "\\b[A-Z][\\w']*",
       },
       {
         className: "number",


### PR DESCRIPTION
While we're still relying on a handwritten language definition for `highlight.js`, this quick hack should make it work with the new comment syntax.